### PR TITLE
Remove deprecations, fix import, add comments and fix spacing, add workflows

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,29 @@
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, labeled, synchronize ]
+
+name: Inspections
+jobs:
+  runPHPCSInspection:
+    if: contains(github.event.pull_request.labels.*.name, 'run analysis')
+    name: Run PHPCS inspection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Analyze code style
+        run: |
+          export PHPCS_DIR=/tmp/phpcs
+          export SNIFFS_DIR=/tmp/sniffs
+          git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
+          git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR
+          git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility
+          $PHPCS_DIR/bin/phpcs --config-set installed_paths $SNIFFS_DIR
+          $PHPCS_DIR/bin/phpcs -p -s -v -n . --standard=./phpcs.xml --extensions=php
+      - name: Check PHP syntax
+        run: find -L .  -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,38 @@
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, labeled, synchronize ]
+
+name: PHPStan Code Analysis
+jobs:
+  phpstan:
+    if: contains(github.event.pull_request.labels.*.name, 'run analysis')
+    name: PHPStan
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "📥 Fetching Repository Contents"
+        uses: actions/checkout@v2
+
+      - name: "💽  Installing PHP, Composer, CS2PR"
+        uses: shivammathur/setup-php@2.10.0
+        with:
+          php-version: '7.4'
+          coverage: none
+          ini-values: display_errors = on, error_reporting = E_ALL
+          tools: phpstan, composer
+
+      - name: "💽  Installing Composer Packages"
+        run: composer install
+
+      - name: "💽  Installing PHPStan Package"
+        run: |
+          composer require phpstan/extension-installer
+
+      - name: "🧪 Test"
+        run: phpstan analyze ./

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,23 @@
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, labeled, synchronize ]
+
+name: Psalm Code Analysis
+jobs:
+  psalm:
+    if: contains(github.event.pull_request.labels.*.name, 'run analysis')
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Psalm
+        uses: docker://vimeo/psalm-github-actions
+        with:
+          composer_require_dev: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.DS_Store
+.idea
+.phpintel
+frm.min.js
+languages/formidable-pro-js.pot
+languages/formidable-js.pot
+temp.xml
+.phpunit.result.cache
+
+# Node
+node_modules
+node_modules/*
+npm-debug.log
+
+# Composer
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "require-dev": {
+        "php-stubs/wordpress-stubs": "^6.1"
+    },
+    "config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"phpstan/extension-installer": true
+		}
+	}
+}

--- a/controllers/FrmLocAppController.php
+++ b/controllers/FrmLocAppController.php
@@ -11,7 +11,7 @@ class FrmLocAppController {
 	 * @return void
 	 */
 	public static function min_version_notice() {
-		$frm_version = is_callable( 'FrmAppHelper::plugin_version' ) ? FrmAppHelper::plugin_version() : 0;
+		$frm_version = is_callable( 'FrmAppHelper::plugin_version' ) ? FrmAppHelper::plugin_version() : '0';
 
 		// Check if Formidable meets minimum requirements.
 		if ( version_compare( $frm_version, self::$min_version, '>=' ) ) {
@@ -19,10 +19,11 @@ class FrmLocAppController {
 		}
 
 		$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
-		echo '<tr class="plugin-update-tr active"><th colspan="' . absint( $wp_list_table->get_column_count() ) . '" class="check-column plugin-update colspanchange"><div class="update-message">' .
-			esc_html__( 'You are running an outdated version of Formidable. This plugin may not work correctly if you do not update Formidable.', 'formidable' ) .
-				'</div></td></tr>';
-
+		if ( $wp_list_table instanceof WP_List_Table ) {
+			echo '<tr class="plugin-update-tr active"><th colspan="' . absint( $wp_list_table->get_column_count() ) . '" class="check-column plugin-update colspanchange"><div class="update-message">' .
+				esc_html__( 'You are running an outdated version of Formidable. This plugin may not work correctly if you do not update Formidable.', 'formidable' ) .
+					'</div></td></tr>';
+		}
 	}
 
 	/**

--- a/controllers/FrmLocAppController.php
+++ b/controllers/FrmLocAppController.php
@@ -1,63 +1,81 @@
 <?php
 
-class FrmLocAppController{
+class FrmLocAppController {
 
+	/**
+	 * @var string
+	 */
 	public static $min_version = '2.01';
 
-	public static function min_version_notice(){
-		$frm_version = is_callable('FrmAppHelper::plugin_version') ? FrmAppHelper::plugin_version() : 0;
+	/**
+	 * @return void
+	 */
+	public static function min_version_notice() {
+		$frm_version = is_callable( 'FrmAppHelper::plugin_version' ) ? FrmAppHelper::plugin_version() : 0;
 
-		// check if Formidable meets minimum requirements
-		if ( version_compare($frm_version, self::$min_version, '>=') ) {
+		// Check if Formidable meets minimum requirements.
+		if ( version_compare( $frm_version, self::$min_version, '>=' ) ) {
 			return;
 		}
 
-		$wp_list_table = _get_list_table('WP_Plugins_List_Table');
-		echo '<tr class="plugin-update-tr active"><th colspan="' . $wp_list_table->get_column_count() . '" class="check-column plugin-update colspanchange"><div class="update-message">'.
-			__('You are running an outdated version of Formidable. This plugin may not work correctly if you do not update Formidable.', 'formidable') .
+		$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
+		echo '<tr class="plugin-update-tr active"><th colspan="' . absint( $wp_list_table->get_column_count() ) . '" class="check-column plugin-update colspanchange"><div class="update-message">' .
+			esc_html__( 'You are running an outdated version of Formidable. This plugin may not work correctly if you do not update Formidable.', 'formidable' ) .
 				'</div></td></tr>';
 
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function include_updater() {
 		if ( class_exists( 'FrmAddon' ) ) {
 			FrmLocUpdate::load_hooks();
 		}
 	}
 
-	public static function menu(){
-		if ( is_callable('FrmAppHelper::get_settings') ) {
-			$frm_settings = FrmAppHelper::get_settings();
-		} else {
+	/**
+	 * @return void
+	 */
+	public static function menu() {
+		if ( ! is_callable( 'FrmAppHelper::get_settings' ) ) {
 			return;
 		}
 
-		add_submenu_page('formidable', $frm_settings->menu .' | Locations', 'Locations', 'frm_create_entries', 'formidable-locations', 'FrmLocAppController::route');
+		$frm_settings = FrmAppHelper::get_settings();
+		add_submenu_page( 'formidable', $frm_settings->menu . ' | Locations', 'Locations', 'frm_create_entries', 'formidable-locations', 'FrmLocAppController::route' );
 	}
 
-	public static function route(){
+	/**
+	 * @return void
+	 */
+	public static function route() {
 		$action = isset( $_REQUEST['frm_action'] ) ? 'frm_action' : 'action';
 		$action = FrmAppHelper::get_param( $action, '', 'get', 'sanitize_title' );
 
-		if ( $action == 'frm_import_locations' ) {
-			return FrmLocImport::import_locations();
-		} else {
-			return self::get_submenu_page();
+		if ( $action === 'frm_import_locations' ) {
+			FrmLocImport::import_locations();
+			return;
 		}
+
+		self::get_submenu_page();
 	}
 
-	public static function get_submenu_page(){
+	/**
+	 * @return void
+	 */
+	public static function get_submenu_page() {
 		$import_options = array(
 			'countries_states' => __( 'Countries and States/Provinces', 'formidable' ),
-			'states_cities'	   => __( 'U.S. States, Counties, and Cities', 'formidable' ),
+			'states_cities'    => __( 'U.S. States, Counties, and Cities', 'formidable' ),
 		);
 
 		$reset_link = wp_nonce_url( add_query_arg( 'reset', 'all' ), 'reset_loc', 'loc_nonce' );
-		if ( isset( $_GET['reset'] ) && $_GET['reset'] == 'all' ) {
+
+		if ( 'all' === FrmAppHelper::simple_get( 'reset' ) ) {
 			FrmLocImport::reset_import();
 		}
 
-		include_once( dirname( dirname( __FILE__ ) ) . '/views/submenu_page.php' );
+		include_once dirname( dirname( __FILE__ ) ) . '/views/submenu_page.php';
 	}
-
 }

--- a/controllers/FrmLocHooksController.php
+++ b/controllers/FrmLocHooksController.php
@@ -1,6 +1,6 @@
 <?php
 
-class FrmLocHooksController{
+class FrmLocHooksController {
 
 	/**
 	 * @return void

--- a/controllers/FrmLocHooksController.php
+++ b/controllers/FrmLocHooksController.php
@@ -2,17 +2,20 @@
 
 class FrmLocHooksController{
 
+	/**
+	 * @return void
+	 */
 	public static function load_admin_hooks() {
 		if ( ! is_admin() ) {
 			return;
 		}
 
-		add_action('admin_init', 'FrmLocAppController::include_updater', 1);
-		add_action('after_plugin_row_formidable-locations/formidable-locations.php', 'FrmLocAppController::min_version_notice');
+		add_action( 'admin_init', 'FrmLocAppController::include_updater', 1 );
+		add_action( 'after_plugin_row_formidable-locations/formidable-locations.php', 'FrmLocAppController::min_version_notice' );
+		add_action( 'admin_menu', 'FrmLocAppController::menu', 27 );
 
-		add_action('admin_menu', 'FrmLocAppController::menu', 27);
-
-		add_action('wp_ajax_frm_import_locations_csv', 'FrmLocImport::import_locations_csv' );
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			add_action( 'wp_ajax_frm_import_locations_csv', 'FrmLocImport::import_locations_csv' );
+		}
 	}
-
 }

--- a/models/FrmLocImport.php
+++ b/models/FrmLocImport.php
@@ -3,14 +3,18 @@
 class FrmLocImport {
 
 	/**
+	 * The total number of states to import in states.csv.
+	 *
 	 * @var int
 	 */
-	private static $states_total = 4028;
+	private static $states_total = 4143;
 
 	/**
+	 * The total number of cities to import in us_cities.csv.
+	 *
 	 * @var int
 	 */
-	private static $cities_total = 51937;
+	private static $cities_total = 51928;
 
 	/**
 	 * Delete all locations data.

--- a/models/FrmLocImport.php
+++ b/models/FrmLocImport.php
@@ -2,18 +2,28 @@
 
 class FrmLocImport{
 
+	/**
+	 * @var int
+	 */
 	private static $states_total = 4028;
+
+	/**
+	 * @var int
+	 */
 	private static $cities_total = 51937;
 
 	/**
-	 * Delete all locations data
+	 * Delete all locations data.
+	 *
 	 * @since 2.1
+	 *
+	 * @return void
 	 */
 	public static function reset_import() {
 		if ( isset( $_GET['loc_nonce'] ) && wp_verify_nonce( $_GET['loc_nonce'], 'reset_loc' ) ) {
 			delete_option( 'frm_usloc_options' );
 			foreach ( array( 'frm_loc_lookup', 'frm_loc_list' ) as $form_key ) {
-				$form_id = FrmForm::getIdByKey( $form_key );
+				$form_id = FrmForm::get_id_by_key( $form_key );
 				if ( $form_id ) {
 					FrmForm::destroy( $form_id );
 				}
@@ -26,22 +36,22 @@ class FrmLocImport{
 	*
 	* @since 2.0
 	*/
-	public static function import_locations(){
+	public static function import_locations() {
 		$data_to_import = FrmAppHelper::get_post_param( 'frm_import_files', '', 'sanitize_title' );
 
-		$form = FrmForm::getOne('frm_loc_list');
+		$form = FrmForm::getOne( 'frm_loc_list' );
 		if ( ! $form ) {
-			$file = dirname( dirname( __FILE__ ) ) .'/templates/locations-forms.xml';
+			$file = dirname( dirname( __FILE__ ) ) . '/templates/locations-forms.xml';
 			FrmXMLHelper::import_xml( $file );
 		}
 
-		$opts = get_option( 'frm_usloc_options' );
+		$opts      = get_option( 'frm_usloc_options' );
 		$remaining = self::remaining_count( $opts, $data_to_import );
 
-		include(dirname(dirname(__FILE__)) . '/views/importing_page.php');
+		include dirname( dirname( __FILE__ ) ) . '/views/importing_page.php';
 	}
 
-	public static function import_locations_csv( $opts ){
+	public static function import_locations_csv( $opts ) {
 		$data_to_import = FrmAppHelper::get_param( 'data_to_import', '', 'post', 'sanitize_title' );
 
 		$opts = self::get_option( 'frm_usloc_options' );
@@ -53,35 +63,42 @@ class FrmLocImport{
 	}
 
 	/**
-	* Import the countries and states
-	*
-	* @since 2.0
-	*/
-	private static function import_countries_states( $opts ){
+	 * Import the countries and states.
+	 *
+	 * @since 2.0
+	 *
+	 * @param array $opts
+	 * @return void
+	 */
+	private static function import_countries_states( $opts ) {
 		echo self::import_global_states_csv( $opts );
 	}
 
 	/**
-	* Import U.S. States, Counties, and Cities
-	*
-	* @since 2.0
-	*/
+	 * Import U.S. States, Counties, and Cities.
+	 *
+	 * @since 2.0
+	 *
+	 * @param array $opts
+	 * @return void
+	 */
 	private static function import_states_cities( $opts ) {
 		echo self::import_cities_with_counties_csv( $opts );
 	}
 
 	/**
-	* Import the states/provinces CSV
-	*
-	* @since 2.0
-	* @return int - number of imported states/provinces
-	*/
-	private static function import_global_states_csv( $opts ){
+	 * Import the states/provinces CSV.
+	 *
+	 * @since 2.0
+	 * @param array $opts
+	 * @return int Number of imported states/provinces
+	 */
+	private static function import_global_states_csv( $opts ) {
 		self::maybe_initialize_option( 'states', $opts );
 
 		if ( $opts['states'] < self::$states_total ) {
 			// Get state form ID
-			$form_id = FrmForm::getIdByKey( 'frm_loc_list' );
+			$form_id = FrmForm::get_id_by_key( 'frm_loc_list' );
 			if ( ! $form_id ) {
 				return $opts['states'];
 			}
@@ -107,32 +124,37 @@ class FrmLocImport{
 	}
 
 	/**
-	* Import the U.S. Cities CSV
-	* Note: intended to be imported with U.S. Counties CSV
-	*
-	* @since 2.0
-	* @return int - number of imported cities
-	*/
-	private static function import_cities_with_counties_csv( $opts ){
+	 * Import the U.S. Cities CSV
+	 * Note: intended to be imported with U.S. Counties CSV
+	 *
+	 * @since 2.0
+	 * @param array $opts
+	 * @return int Number of imported cities
+	 */
+	private static function import_cities_with_counties_csv( $opts ) {
 		self::maybe_initialize_option( 'cities', $opts );
 
 		if ( $opts['cities'] < self::$cities_total ) {
 			// Get city form ID
-			$form_id = FrmForm::getIdByKey( 'frm_loc_list' );
+			$form_id = FrmForm::get_id_by_key( 'frm_loc_list' );
 			if ( ! $form_id ) {
 				return $opts['cities'];
 			}
 
 			// Import cities from CSV
-			$filename = dirname( dirname( __FILE__ ) ) . '/locations_data/us_cities.csv';
-			$opts['cities'] = FrmProXMLHelper::import_csv( $filename, $form_id,
+			$filename       = dirname( dirname( __FILE__ ) ) . '/locations_data/us_cities.csv';
+			$opts['cities'] = FrmProXMLHelper::import_csv(
+				$filename,
+				$form_id,
 				array(
 					1 => FrmField::get_id_by_key( 'frm_loc_city' ),
 					2 => FrmField::get_id_by_key( 'frm_loc_county' ),
 					4 => FrmField::get_id_by_key( 'frm_loc_state' ),
 					5 => FrmField::get_id_by_key( 'frm_loc_state_abr' ),
 					6 => FrmField::get_id_by_key( 'frm_loc_country_code2' ),
-				), 1, $opts['cities'] + 1
+				),
+				1,
+				$opts['cities'] + 1
 			);
 
 			update_option( 'frm_usloc_options', $opts );
@@ -141,7 +163,11 @@ class FrmLocImport{
 		return $opts['cities'];
 	}
 
-	private static function get_option( $opt_name ){
+	/**
+	 * @param string $opt_name
+	 * @return array
+	 */
+	private static function get_option( $opt_name ) {
 		$opts = get_option( $opt_name );
 		if ( ! is_array( $opts ) ) {
 			$opts = array();
@@ -150,30 +176,43 @@ class FrmLocImport{
 		return $opts;
 	}
 
+	/**
+	 * @param string $item 'states' or 'cities'.
+	 * @param array  $opts
+	 * @return void
+	 */
 	private static function maybe_initialize_option( $item, &$opts ) {
 		if ( ! isset( $opts[ $item ] ) ) {
 			$opts[ $item ] = 1;
 		}
 	}
 
-	private static function remaining_count( $opts, $data_to_import ){
-		// Get number of imported entries
-		$imported = $total = 0;
+	/**
+	 * @param array $opts
+	 * @param string $data_to_import 'countries_states' or 'states_cities'.
+	 * @return int
+	 */
+	private static function remaining_count( $opts, $data_to_import ) {
+		// Get number of imported entries.
+		$imported   = $total = 0;
+		$data_types = array(
+			'states' => 0,
+			'cities' => 0
+		);
 
-		$data_types = array( 'states' => 0, 'cities' => 0 );
 		foreach ( $data_types as $loc => $loc_imported ) {
 			if ( isset( $opts[ $loc ] ) ) {
 				$data_types[ $loc ] = (int) $opts[ $loc ];
 			}
 		}
 
-		// Get expected total
-		if ( $data_to_import == 'countries_states' ) {
+		// Get expected total.
+		if ( $data_to_import === 'countries_states' ) {
 			$imported = $data_types['states'];
-			$total = self::$states_total;
-		} else if ( $data_to_import == 'states_cities' ) {
+			$total    = self::$states_total;
+		} elseif ( $data_to_import === 'states_cities' ) {
 			$imported = $data_types['cities'];
-			$total = self::$cities_total;
+			$total    = self::$cities_total;
 		}
 
 		return $total - $imported;

--- a/models/FrmLocImport.php
+++ b/models/FrmLocImport.php
@@ -195,7 +195,7 @@ class FrmLocImport {
 	}
 
 	/**
-	 * @param array  $opts
+	 * @param mixed  $opts
 	 * @param string $data_to_import 'countries_states' or 'states_cities'.
 	 * @return int
 	 */
@@ -208,9 +208,11 @@ class FrmLocImport {
 			'cities' => 0,
 		);
 
-		foreach ( $data_types as $loc => $loc_imported ) {
-			if ( isset( $opts[ $loc ] ) ) {
-				$data_types[ $loc ] = (int) $opts[ $loc ];
+		if ( is_array( $opts ) ) {
+			foreach ( $data_types as $loc => $loc_imported ) {
+				if ( isset( $opts[ $loc ] ) ) {
+					$data_types[ $loc ] = (int) $opts[ $loc ];
+				}
 			}
 		}
 

--- a/models/FrmLocUpdate.php
+++ b/models/FrmLocUpdate.php
@@ -3,17 +3,17 @@
 class FrmLocUpdate extends FrmAddon {
 
 	/**
-	 * @param string
+	 * @var string
 	 */
 	public $plugin_file;
 
 	/**
-	 * @param string
+	 * @var string
 	 */
 	public $plugin_name = 'Locations';
 
 	/**
-	 * @param string
+	 * @var string
 	 */
 	public $version = '2.02';
 

--- a/models/FrmLocUpdate.php
+++ b/models/FrmLocUpdate.php
@@ -2,8 +2,19 @@
 
 class FrmLocUpdate extends FrmAddon {
 
+	/**
+	 * @param string
+	 */
 	public $plugin_file;
+
+	/**
+	 * @param string
+	 */
 	public $plugin_name = 'Locations';
+
+	/**
+	 * @param string
+	 */
 	public $version = '2.02';
 
 	public function __construct() {
@@ -11,6 +22,9 @@ class FrmLocUpdate extends FrmAddon {
 		parent::__construct();
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_hooks() {
 		add_filter( 'frm_include_addon_page', '__return_true' );
 		new FrmLocUpdate();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<ruleset name="Formidable Forms">
+	<description>Formidable Forms rules for PHP_CodeSniffer</description>
+
+	<exclude-pattern>vendor/*</exclude-pattern>
+	<exclude-pattern>node_modules/*</exclude-pattern>
+	<exclude-pattern>bin/*</exclude-pattern>
+
+	<arg name="extensions" value="php" />
+	<arg value="nsp" />
+
+	<rule ref="WordPress">
+		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle" />
+		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.VariableComment.Missing" />
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing" />
+		<exclude name="Squiz.Commenting.PostStatementComment.Found" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="formidable"/>
+				<element value="formidable-chat"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="Squiz.Scope.StaticThisUsage" />
+
+	<rule ref="PEAR.NamingConventions.ValidClassName.StartWithCapital">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
 	level: max
-	reportUnmatchedIgnoredErrors: true
+	reportUnmatchedIgnoredErrors: false
 	bootstrapFiles:
 		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
 		- stubs
@@ -17,4 +17,3 @@ parameters:
 		- '#no (typehint|value type|return typehint)+ specified.#'
 		- '#has no return type specified#'
 		- '#with no type specified#'
-		- '#has no type specified.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,20 @@
+parameters:
+	level: max
+	reportUnmatchedIgnoredErrors: true
+	bootstrapFiles:
+		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+		- stubs
+	excludePaths:
+		- */node_modules/*
+		- */tests/*
+		- */images/*
+		- */js/*
+		- */vendor/*
+		- */css/*
+	ignoreErrors:
+		- '#is always (false|true)+.#'
+		- '#might not be defined.#'
+		- '#no (typehint|value type|return typehint)+ specified.#'
+		- '#has no return type specified#'
+		- '#with no type specified#'
+		- '#has no type specified.#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<psalm
+	errorLevel="2"
+	resolveFromConfigFile="true"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="https://getpsalm.org/schema/config"
+	xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+	<projectFiles>
+		<file name="us_locations.php" />
+		<directory name="controllers" />
+		<directory name="models" />
+		<ignoreFiles>
+			<directory name="vendor" />
+			<directory name="views" />
+		</ignoreFiles>
+	</projectFiles>
+	<stubs>
+		<file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php" />
+		<file name="stubs" />
+	</stubs>
+	<issueHandlers>
+		<InvalidGlobal>
+			<errorLevel type="suppress">
+				<directory name="controllers" />
+				<directory name="models" />
+			</errorLevel>
+		</InvalidGlobal>
+		<UndefinedDocblockClass>
+			<errorLevel type="suppress">
+				<directory name="controllers" />
+				<directory name="models" />
+			</errorLevel>
+		</UndefinedDocblockClass>
+		<TooManyArguments>
+			<errorLevel type="suppress">
+				<referencedFunction name="apply_filters" />
+			</errorLevel>
+		</TooManyArguments>
+		<UnresolvableInclude>
+			<errorLevel type="suppress">
+				<directory name="controllers" />
+				<directory name="models" />
+			</errorLevel>
+		</UnresolvableInclude>
+		<MissingParamType>
+			<errorLevel type="suppress">
+				<file name="models/FrmLocImport.php" />
+			</errorLevel>
+		</MissingParamType>
+		<MissingReturnType>
+			<errorLevel type="suppress">
+				<file name="models/FrmLocImport.php" />
+			</errorLevel>
+		</MissingReturnType>
+	</issueHandlers>
+</psalm>

--- a/stubs
+++ b/stubs
@@ -1,0 +1,520 @@
+<?php
+
+define( 'MINUTE_IN_SECONDS', 60 );
+define( 'HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS );
+define( 'DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS );
+define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
+define( 'MONTH_IN_SECONDS', 30 * DAY_IN_SECONDS );
+define( 'YEAR_IN_SECONDS', 365 * DAY_IN_SECONDS );
+define( 'EMPTY_TRASH_DAYS', 30 );
+define( 'ABSPATH', realpath( __FILE__ . '/../../../../' ) );
+define( 'WP_PLUGIN_DIR', realpath( __FILE__ . '/../' ) );
+define( 'WPINC', 'wp-includes' );
+define( 'OBJECT', 'OBJECT' );
+define( 'OBJECT_K', 'OBJECT_K' );
+define( 'ARRAY_A', 'ARRAY_A' );
+define( 'EP_PAGES', 4096 );
+define( 'EP_PERMALINK', 1 );
+define( 'COOKIEHASH', '' );
+define( 'COOKIE_DOMAIN', false );
+define( 'COOKIEPATH', '/' );
+
+class FrmAddon {
+	public function __construct() {
+	}
+	public function activate_defined_license() {
+	}
+	public function set_active( $is_active ) {
+	}
+	public function clear_license() {
+	}
+}
+
+class FrmAppHelper {
+	public static function permission_check( $permission, $show_message = 'show' ) {
+	}
+	public static function get_param( $param, $default = '', $src = 'get', $sanitize = '' ) {
+	}
+	public static function get_post_param( $param, $default = '', $sanitize = '', $serialized = false ) {
+	}
+	public static function get_localized_date( $date_format, $date ) {
+	}
+	public static function get_settings( $args = array() ) {
+	}
+	public static function is_admin_page( $page = 'formidable' ) {
+	}
+	public static function plugin_path() {
+	}
+	public static function checked( $values, $current ) {
+	}
+	public static function check_selected( $values, $current ) {
+	}
+	public static function truncate( $str, $length, $minword = 3, $continue = '...' ) {
+	}
+	public static function locales( $type = 'date' ) {
+	}
+	public static function simple_get( $param, $sanitize = 'sanitize_text_field', $default = '' ) {
+	}
+	public static function get_admin_header( $atts ) {
+	}
+	public static function esc_textarea( $text, $is_rich_text = false ) {
+	}
+	public static function get_ip_address() {
+	}
+	public static function get_server_value( $value ) {
+	}
+	public static function kses( $value, $allowed = array() ) {
+	}
+	public static function plugin_version() {
+	}
+	public static function plugin_url() {
+	}
+	public static function wp_pages_dropdown( $args = array(), $page_id = '', $truncate = false ) {
+	}
+	public static function wp_roles_dropdown( $field_name, $capability, $multiple = 'single' ) {
+	}
+	public static function maybe_json_decode( $string, $single_to_array = true ) {
+	}
+	public static function is_admin() {
+	}
+	/**
+	 * @param array $args
+	 * @return void
+	 */
+	public static function maybe_autocomplete_pages_options( $args ) {
+	}
+	/**
+	 * @return void
+	 */
+	public static function show_header_logo() {
+	}
+	public static function svg_logo( $atts = array() ) {
+	}
+	public static function icon_by_class( $class, $atts = array() ) {
+	}
+	public static function show_search_box( $atts ) {
+	}
+	/**
+	 * @param string|array $capability
+	 * @return void
+	 */
+	public static function roles_options( $capability ) {
+	}
+	/**
+	 * @return bool
+	 */
+	public static function ips_saved() {
+	}
+	public static function get_formatted_time( $date, $date_format = '', $time_format = '' ) {
+	}
+	/**
+	 * @param array $atts {
+	 *     @type array  $link_hook
+	 *     @type string $new_link
+	 *     @type string $class
+	 *     @type string $button_text
+	 * }
+	 * @return void
+	 */
+	public static function add_new_item_link( $atts ) {
+	}
+	/**
+	 * @param array $atts
+	 * @param bool  $echo
+	 * @return string|void
+	 */
+	public static function array_to_html_params( $atts, $echo = false ) {
+	}
+	/**
+	 * @return string Site URL
+	 */
+	public static function site_url() {
+	}
+	public static function sanitize_value( $sanitize, &$value ) {
+	}
+	/**
+	 * @return bool
+	 */
+	public static function is_preview_page() {
+	}
+	/**
+	 * @return bool
+	 */
+	public static function doing_ajax() {
+	}
+	/**
+	 * @param int $from in seconds
+	 * @param int|string $to in seconds
+	 * @return string $time_ago
+	 */
+	public static function human_time_diff( $from, $to = '', $levels = 1 ) {
+	}
+	/**
+	 * @param mixed $value
+	 * @param string
+	 * @return bool
+	 */
+	public static function is_empty_value( $value, $empty = '' ) {
+	}
+	public static function array_flatten( $array, $keys = 'keep' ) {
+	}
+	/**
+	 * @param array|string $args
+	 * @param string       $page
+	 * @return string
+	 */
+	public static function admin_upgrade_link( $args, $page = '' ) {
+	}
+	/**
+	 * @param Closure $echo_function
+	 * @param bool    $echo
+	 * @return string|void
+	 */
+	public static function clip( $echo_function, $echo = false ) {
+	}
+	/**
+	 * @return string
+	 */
+	public static function js_suffix() {
+	}
+	/**
+	 * @param string $location
+	 * @return void
+	 */
+	public static function localize_script( $location ) {
+	}
+	/**
+	 * @return bool
+	 */
+	public static function on_form_listing_page() {
+	}
+	/**
+	 * @return string
+	 */
+	public static function make_affiliate_url( $url ) {
+	}
+	/**
+	 * @return void
+	 */
+	public static function include_svg() {
+	}
+	/**
+	 * @param array $values
+	 * @param array $keys
+	 * @return array
+	 */
+	public static function maybe_filter_array( $values, $keys ) {
+	}
+	public static function is_not_empty_value( $value, $empty = '' ) {
+	}
+	/**
+	 * @param array|string $value
+	 * @return void
+	 */
+	public static function decode_specialchars( &$value ) {
+	}
+	/**
+	 * @return void
+	 */
+	public static function save_combined_js() {
+	}
+	/**
+	 * @param string $role
+	 * @return bool
+	 */
+	public static function current_user_can( $role ) {
+	}
+	public static function get_user_id_param( $user_id ) {
+	}
+	/**
+	 * @param string $name
+	 * @param string $table_name
+	 * @param string $column
+	 * @param int    $id
+	 * @param int    $num_chars
+	 * @return string
+	 */
+	public static function get_unique_key( $name, $table_name, $column, $id = 0, $num_chars = 5 ) {
+	}
+	/**
+	 * @param string $handle
+	 */
+	public static function script_version( $handle, $default = 0 ) {
+	}
+	/**
+	 * @return void
+	 */
+	public static function unserialize_or_decode( &$value ) {
+	}
+	/**
+	 * @return string
+	 */
+	public static function get_menu_name() {
+	}
+	/**
+	 * @param string|array $needed_role
+	 * @return bool
+	 */
+	public static function user_has_permission( $needed_role ) {
+	}
+	/**
+	 * @param string $val
+	 * @return string
+	 */
+	public static function replace_quotes( $val ) {
+	}
+	public static function use_wpautop( $content ) {
+	}
+	/**
+	 * @param string $table
+	 * @return bool|array
+	 */
+	public static function setup_edit_vars( $record, $table, $fields = '', $default = false, $post_values = array(), $args = array() ) {
+	}
+	/**
+	 * @param string $type
+	 * @return void
+	 */
+	public static function trigger_hook_load( $type, $object = null ) {
+	}
+	/**
+	 * @return void
+	 */
+	public static function remove_get_action() {
+	}
+	/**
+	 * @return bool
+	 */
+	public static function pro_is_installed() {
+	}
+	/**
+	 * @param string $feature
+	 * @return bool
+	 */
+	public static function show_new_feature( $feature ) {
+	}
+	/**
+	 * @param array $post_values
+	 * @return boolean|int
+	 */
+	public static function custom_style_value( $post_values ) {
+	}
+	/**
+	 * @param string $permission
+	 * @return false|string
+	 */
+	public static function permission_nonce_error( $permission, $nonce_name = '', $nonce = '' ) {
+	}
+	/**
+	 * @param string $url
+	 * @param string $expected_extension
+	 * @return bool
+	 */
+	public static function validate_url_is_in_s3_bucket( $url, $expected_extension ) {
+	}
+	/**
+	 * @param string $view
+	 * @return bool
+	 */
+	public static function is_style_editor_page( $view = '' ) {
+	}
+}
+
+class FrmField {
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public static function getAll( $where = array(), $order_by = '', $limit = '', $blog_id = false ) {
+	}
+	public static function create( $values, $return = true ) {
+	}
+	public static function get_option( $field, $option ) {
+	}
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public static function getOne( $id, $filter = false ) {
+	}
+	public static function is_option_true( $field, $option ) {
+	}
+	public static function is_option_true_in_object( $field, $option ) {
+	}
+	public static function get_all_for_form( $form_id, $limit = '', $inc_embed = 'exclude', $inc_repeat = 'include' ) {
+	}
+	public static function is_repeating_field( $field ) {
+	}
+	public static function is_no_save_field( $type ) {
+	}
+	public static function get_all_types_in_form( $form_id, $type, $limit = '', $inc_sub = 'exclude' ) {
+	}
+	public static function no_save_fields() {
+	}
+	public static function get_field_type( $field ) {
+	}
+	public static function is_field_type( $field, $is_type ) {
+	}
+	public static function update( $id, $values ) {
+	}
+	public static function is_field_with_multiple_values( $field ) {
+	}
+	public static function get_type( $id, $col = 'type' ) {
+	}
+	/**
+	 * @return bool
+	 */
+	public static function is_multiple_select( $field ) {
+	}
+	/**
+	 * @param array $field
+	 * @return bool
+	 */
+	public static function is_required( $field ) {
+	}
+	public static function is_read_only( $field ) {
+	}
+	public static function is_option_empty( $field, $option ) {
+	}
+	public static function get_option_in_array( $field, $option ) {
+	}
+	public static function get_option_in_object( $field, $option ) {
+	}
+	public static function is_option_true_in_array( $field, $option ) {
+	}
+	public static function maybe_get_field( &$field ) {
+	}
+	/**
+	 * @return void
+	 */
+	public static function delete_form_transient( $form_id ) {
+	}
+	public static function is_option_value_in_object( $field, $option ) {
+	}
+	/**
+	 * @param string|int $id
+	 * @return string
+	 */
+	public static function get_key_by_id( $id ) {
+	}
+	/**
+	 * @param string $key
+	 * @return int
+	 */
+	public static function get_id_by_key( $key ) {
+	}
+	/**
+	 * @param array|object $field
+	 * @return bool
+	 */
+	public static function is_radio( $field ) {
+	}
+	/**
+	 * @param array|object $field
+	 * @return bool
+	 */
+	public static function is_checkbox( $field ) {
+	}
+	/**
+	 * @param array|object $field
+	 * @return bool
+	 */
+	public static function is_image( $field ) {
+	}
+	/**
+	 * @return array
+	 */
+	public static function pro_field_selection() {
+	}
+}
+
+class FrmForm {
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public static function getOne( $id, $blog_id = false ) {
+	}
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public static function getAll( $where = array(), $order_by = '', $limit = '' ) {
+	}
+	public static function maybe_get_form( &$form ) {
+	}
+	public static function translatable_strings( $form ) {
+	}
+	/**
+	 * @return array of forms
+	 */
+	public static function get_published_forms( $query = array(), $limit = 999, $inc_children = 'exclude' ) {
+	}
+	/**
+	 * @param array $atts
+	 * @return mixed
+	 */
+	public static function get_option( $atts ) {
+	}
+	/**
+	 * @param string|int $id
+	 * @return int|bool
+	 */
+	public static function destroy( $id ) {
+	}
+	public static function get_admin_params( $form = null ) {
+	}
+	/**
+	 * @param array $values
+	 * @return int|false
+	 */
+	public static function create( $values ) {
+	}
+	/**
+	 * @return int|bool
+	 */
+	public static function update( $id, $values, $create_link = false ) {
+	}
+	/**
+	 * @param string $key
+	 * @return int
+	 */
+	public static function get_id_by_key( $key ) {
+	}
+	/**
+	 * @param int $id
+	 * @return string
+	 */
+	public static function get_key_by_id( $id ) {
+	}
+	/**
+	 * @return void
+	 */
+	public static function clear_form_cache() {
+	}
+	/**
+	 * @return int|bool ID on success or false on failure
+	 */
+	public static function duplicate( $id, $template = false, $copy_keys = false, $blog_id = false ) {
+	}
+	public static function get_params( $form = null ) {
+	}
+	public static function get_current_form_id( $default_form = 'none' ) {
+	}
+}
+
+class FrmXMLHelper {
+	public static function import_xml_now( $xml, $installing_template = false ) {
+	}
+	public static function cdata( $str ) {
+	}
+    /**
+     * @param string $file
+     * @return array
+     */
+    public static function import_xml( $file ) {
+    }
+}
+
+class FrmProXMLHelper {
+    /**
+     * @param string     $path
+     * @param string|int $form_id
+     * @param array      $field_ids
+     * @param int        $entry_key
+     * @param int        $start_row
+     * @param string     $del
+     * @param int        $max
+     * @return int
+     */
+    public static function import_csv( $path, $form_id, $field_ids, $entry_key = 0, $start_row = 2, $del = ',', $max = 250 ) {
+    }
+}

--- a/us_locations.php
+++ b/us_locations.php
@@ -8,21 +8,27 @@ Author URI: http://strategy11.com
 Version: 2.02
 */
 
-function frm_loc_forms_autoloader($class_name) {
-	$path = dirname(__FILE__);
+/**
+ * Autoloader for Locations add on.
+ *
+ * @param string $class_name
+ * @return void
+ */
+function frm_loc_forms_autoloader( $class_name ) {
+	$path = dirname( __FILE__ );
 
 	// Only load Frm classes here
-	if ( ! preg_match('/^FrmLoc.+$/', $class_name) ) {
+	if ( ! preg_match( '/^FrmLoc.+$/', $class_name ) ) {
 		return;
 	}
 
-	if ( preg_match('/^.+Controller$/', $class_name) ) {
-		$path .= '/controllers/'. $class_name .'.php';
+	if ( preg_match( '/^.+Controller$/', $class_name ) ) {
+		$path .= '/controllers/' . $class_name . '.php';
 	} else {
-		$path .= '/models/'. $class_name .'.php';
+		$path .= '/models/' . $class_name . '.php';
 	}
 
-	if ( file_exists($path) ) {
+	if ( file_exists( $path ) ) {
 		include $path;
 	}
 }

--- a/us_locations.php
+++ b/us_locations.php
@@ -23,12 +23,12 @@ function frm_loc_forms_autoloader($class_name) {
 	}
 
 	if ( file_exists($path) ) {
-		include($path);
+		include $path;
 	}
 }
 
 // Add the autoloader
-spl_autoload_register('frm_loc_forms_autoloader');
+spl_autoload_register( 'frm_loc_forms_autoloader' );
 
 // Load hooks
 FrmLocHooksController::load_admin_hooks();

--- a/views/importing_page.php
+++ b/views/importing_page.php
@@ -6,7 +6,6 @@
 	<div id="poststuff" class="metabox-holder">
 		<div id="post-body">
 			<div id="post-body-content">
-
 				<div class="postbox ">
 					<h3 class="hndle"><span><?php esc_html_e( 'Importing Locations', 'formidable' ); ?></span></h3>
 					<div class="inside">
@@ -17,40 +16,29 @@
 							</div>
 						</div>
 						<!-- what about nonce? -->
-
-
-						<script type="text/javascript">
-
-						function frmImportLocationsCsv(){
-							jQuery.ajax({
-								type:"POST",url:ajaxurl,
-								data:'action=frm_import_locations_csv&frm_skip_cookie=1&data_to_import=<?php echo esc_js( $data_to_import ); ?>',
-							success:function(imported){
-								var max = jQuery('.frm_progress_bar').attr('aria-valuemax');
-								var percent = (imported / max) * 100;
-								var remaining = max - imported;
-								jQuery('.frm_progress_bar').css('width', percent +'%').attr('aria-valuenow', imported);
-		
-								if(parseInt(remaining) > 0){
-									jQuery('.frm_csv_remaining').html(remaining);
-									frmImportLocationsCsv();
-								}else{
-									jQuery(document.getElementById('frm_import_message')).html('Import complete');
-									setTimeout(function(){
-										location.href = '?page=formidable';
-									}, 2000);
-								}
+						<script>
+							function frmImportLocationsCsv() {
+								jQuery.ajax({
+									type: "POST",
+									url: ajaxurl,
+									data: 'action=frm_import_locations_csv&frm_skip_cookie=1&data_to_import=<?php echo esc_js( $data_to_import ); ?>',
+									success: imported => {
+										const max       = jQuery( '.frm_progress_bar' ).attr( 'aria-valuemax' );
+										const percent   = ( imported / max ) * 100;
+										const remaining = max - imported;
+										jQuery('.frm_progress_bar').css( 'width', percent +'%' ).attr( 'aria-valuenow', imported );
+										if ( parseInt( remaining ) > 0 ) {
+											jQuery( '.frm_csv_remaining' ).text( remaining );
+											frmImportLocationsCsv();
+										} else {
+											jQuery( document.getElementById( 'frm_import_message' ) ).text( 'Import complete' );
+											setTimeout( () => location.href = '?page=formidable', 2000 );
+										}
+									}
+								});	
 							}
-							});	
-						}
-
-						jQuery(document).ready(function(){
-							frmImportLocationsCsv();
-						});
-
-						</script>
-						
-						
+							jQuery( document ).ready( frmImportLocationsCsv );
+						</script>						
 					</div>
 				</div>
 			</div>

--- a/views/importing_page.php
+++ b/views/importing_page.php
@@ -1,19 +1,19 @@
 <div class="wrap">
-    <div class="frmicon icon32"><br/></div>
-    <h2><?php _e( 'Locations', 'formidable' ); ?></h2>
+	<div class="frmicon icon32"><br/></div>
+	<h2><?php esc_html_e( 'Locations', 'formidable' ); ?></h2>
 
-    <?php include(FrmAppHelper::plugin_path() .'/classes/views/shared/errors.php'); ?>
+	<?php include FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php'; ?>
 	<div id="poststuff" class="metabox-holder">
 		<div id="post-body">
 			<div id="post-body-content">
 
 				<div class="postbox ">
-					<h3 class="hndle"><span><?php _e( 'Importing Locations', 'formidable' ) ?></span></h3>
+					<h3 class="hndle"><span><?php esc_html_e( 'Importing Locations', 'formidable' ); ?></span></h3>
 					<div class="inside">
-						<div class="with_frm_style" id="frm_import_message"><span class="frm_message" style="padding:7px;"><?php printf(__( '%1$s entries are importing', 'formidable' ), '<span class="frm_csv_remaining">'. $remaining .'</span>') ?></span></div>
+						<div class="with_frm_style" id="frm_import_message"><span class="frm_message" style="padding:7px;"><?php printf( esc_html__( '%1$s entries are importing', 'formidable' ), '<span class="frm_csv_remaining">' . absint( $remaining ) . '</span>' ); ?></span></div>
 
 						<div class="frm_progress">
-							<div class="frm_progress_bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="<?php echo esc_attr( $remaining ) ?>" style="width:0%;">
+							<div class="frm_progress_bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="<?php echo esc_attr( $remaining ); ?>" style="width:0%;">
 							</div>
 						</div>
 						<!-- what about nonce? -->
@@ -22,16 +22,16 @@
 						<script type="text/javascript">
 
 						function frmImportLocationsCsv(){
-						    jQuery.ajax({
+							jQuery.ajax({
 								type:"POST",url:ajaxurl,
-								data:'action=frm_import_locations_csv&frm_skip_cookie=1&data_to_import=<?php echo $data_to_import ?>',
-						    success:function(imported){
+								data:'action=frm_import_locations_csv&frm_skip_cookie=1&data_to_import=<?php echo esc_js( $data_to_import ); ?>',
+							success:function(imported){
 								var max = jQuery('.frm_progress_bar').attr('aria-valuemax');
 								var percent = (imported / max) * 100;
 								var remaining = max - imported;
 								jQuery('.frm_progress_bar').css('width', percent +'%').attr('aria-valuenow', imported);
 		
-						        if(parseInt(remaining) > 0){
+								if(parseInt(remaining) > 0){
 									jQuery('.frm_csv_remaining').html(remaining);
 									frmImportLocationsCsv();
 								}else{
@@ -39,9 +39,9 @@
 									setTimeout(function(){
 										location.href = '?page=formidable';
 									}, 2000);
-						        }
-						    }
-						    });	
+								}
+							}
+							});	
 						}
 
 						jQuery(document).ready(function(){
@@ -55,5 +55,5 @@
 				</div>
 			</div>
 		</div>
-    </div>
+	</div>
 </div>

--- a/views/submenu_page.php
+++ b/views/submenu_page.php
@@ -1,33 +1,34 @@
 <div class="wrap">
-    <div id="icon-options-general" class="icon32"><br></div>
-    <h2><?php _e('Locations', 'formidable') ?></h2>
-	
+	<div id="icon-options-general" class="icon32"><br></div>
+	<h2><?php esc_html_e( 'Locations', 'formidable' ); ?></h2>
 
 	<div class="postbox">
 		<div class="inside with_frm_style">
 			<form method="post" id="frm_import_locations">
 				<input type="hidden" name="frm_action" value="frm_import_locations" />
-				<?php wp_nonce_field('import-locations-nonce', 'import-locations'); ?>
+				<?php wp_nonce_field( 'import-locations-nonce', 'import-locations' ); ?>
 
-				<label><?php _e( 'Which locations would you like to import?', 'formidable' ); ?></label><br/>
+				<label><?php esc_html_e( 'Which locations would you like to import?', 'formidable' ); ?></label><br/>
 
-                <select name="frm_import_files">
+				<select name="frm_import_files">
 				<?php
-				foreach ( $import_options as $o => $opt ) { ?>
-                    <option value="<?php echo esc_attr( $o ) ?>"><?php
-						echo esc_html( $opt );
-                ?></option>
-                <?php
-                } ?>
-                </select>
+				foreach ( $import_options as $o => $opt ) {
+					?>
+					<option value="<?php echo esc_attr( $o ); ?>">
+						<?php echo esc_html( $opt ); ?>
+					</option>
+					<?php
+				}
+				?>
+				</select>
 
 				<p class="submit">
-					<input type="submit" value="<?php esc_attr_e( 'Import Selection', 'formidable' ) ?>" class="button-primary" />
+					<input type="submit" value="<?php esc_attr_e( 'Import Selection', 'formidable' ); ?>" class="button-primary" />
 				</p>
 			</form>
 
-			<a href="<?php echo esc_url(  $reset_link ) ?>" onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete your locations forms and data?', 'formidable' ) ) ?>')">
-				<?php esc_html_e( 'Reset Locations', 'formidable' ) ?>
+			<a href="<?php echo esc_url( $reset_link ); ?>" onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete your locations forms and data?', 'formidable' ) ); ?>')">
+				<?php esc_html_e( 'Reset Locations', 'formidable' ); ?>
 			</a>
 		</div>
 	</div>


### PR DESCRIPTION
- Also fixes https://github.com/Strategy11/formidable-locations/issues/7
- Fixes https://github.com/Strategy11/formidable-locations/issues/6 which is a result of this update https://github.com/Strategy11/formidable-locations/commit/28b37d56c25af95dda3c76518b06aecf9e13cb08 where 9 entries were removed.
- The states count was also updated as it wasn't accurate.
- Adds PHPStan, Psalm, and PHPCS configurations and workflows.
- Fixes spacing, adds type comments, validates types more.
- Adding additional content escaping.

There's also an issue with importing the "US Tax Department" "city" with a "1920" state value. That's fixed separately in https://github.com/Strategy11/formidable-locations/pull/9 and I merged it into this branch now, so it should work as well here.