### PR TITLE
Remove incorrect "NJ" cell value from cities csv

### DIFF
--- a/locations_data/us_cities.csv
+++ b/locations_data/us_cities.csv
@@ -27840,8 +27840,8 @@ ID,city,county,countyID,statename,stateabbreviation,country
 27846,Newport,Cumberland County,1902,New Jersey,NJ,US
 27847,Newton,Sussex County,1915,New Jersey,NJ,US
 27848,Newtonville,Atlantic County,1910,New Jersey,NJ,US
-27849,NJ,US Income Tax,Mercer County,1920,New Jersey,NJ,US
-27850,NJ,US Taxation Dept,Mercer County,1920,New Jersey,NJ,US
+27849,US Income Tax,Mercer County,1920,New Jersey,NJ,US
+27850,US Taxation Dept,Mercer County,1920,New Jersey,NJ,US
 27851,Norma,Salem County,1917,New Jersey,NJ,US
 27852,Normandy Beach,Ocean County,1919,New Jersey,NJ,US
 27853,North Arlington,Bergen County,1908,New Jersey,NJ,US


### PR DESCRIPTION
I noticed this while importing locations data and trying to use a lookup.

One state was "1920"
<img width="107" alt="StateProvince" src="https://user-images.githubusercontent.com/9134515/227581751-b0283d45-9118-44d5-b7fa-8b47b5316168.png">

Pointing to the "US Income Tax"/"US Taxation Department" "cities".
<img width="158" alt="County Area" src="https://user-images.githubusercontent.com/9134515/227581800-b1a90567-04c7-42db-aee5-2fd2619327b6.png">

All of the data is offset because there's an extra "NJ" in the csv for the city column.

**Before**
<img width="917" alt="Screen Shot 2023-03-24 at 12 58 21 PM" src="https://user-images.githubusercontent.com/9134515/227581961-8eab7ed7-857d-48c3-b309-5987487cf414.png">

**After**
<img width="1001" alt="Screen Shot 2023-03-24 at 1 22 27 PM" src="https://user-images.githubusercontent.com/9134515/227583534-ca21c26a-409f-49c0-8001-dfaac6598aa0.png">
